### PR TITLE
Add Query methods to builder for use with standard database/sql package

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -17,6 +17,8 @@ type Builder interface {
 	String() string
 	// Prepare returns the underlying query as a named statement.
 	Prepare() (string, map[string]interface{})
+	// Query returns the underlying query as a regular statement.
+	Query() (string, []interface{})
 	// Statement returns underlying statement.
 	Statement() stmt.Statement
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ulule/loukoum/format"
 	"github.com/ulule/loukoum/stmt"
 	"github.com/ulule/loukoum/types"
 )
@@ -21,17 +20,6 @@ type Builder interface {
 	Query() (string, []interface{})
 	// Statement returns underlying statement.
 	Statement() stmt.Statement
-}
-
-// rawify will replace given arguments in query to obtain a human readable statement.
-// Be advised, this function is not optimized, use with caution.
-func rawify(query string, args map[string]interface{}) string {
-	for key, arg := range args {
-		key = fmt.Sprint(":", key)
-		value := format.Value(arg)
-		query = strings.Replace(query, key, value, 1)
-	}
-	return query
 }
 
 // ToColumn takes an empty interfaces and returns a Column instance.

--- a/builder/delete.go
+++ b/builder/delete.go
@@ -83,30 +83,23 @@ func (b Delete) Returning(values ...interface{}) Delete {
 
 // String returns the underlying query as a raw statement.
 func (b Delete) String() string {
-	return rawify(b.Prepare())
+	var ctx types.RawContext
+	b.query.Write(&ctx)
+	return ctx.Query()
 }
 
 // Prepare returns the underlying query as a named statement.
 func (b Delete) Prepare() (string, map[string]interface{}) {
-	ctx := types.NewContext()
-	b.query.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Values()
-
-	return query, args
+	var ctx types.NamedContext
+	b.query.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Query returns the underlying query as a regular statement.
 func (b Delete) Query() (string, []interface{}) {
-	ctx := types.NewContext()
-	ctx.Prefix = types.PostgresPrefix
-	b.query.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Args()
-
-	return query, args
+	var ctx types.StdContext
+	b.query.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Statement returns underlying statement.

--- a/builder/delete.go
+++ b/builder/delete.go
@@ -97,6 +97,18 @@ func (b Delete) Prepare() (string, map[string]interface{}) {
 	return query, args
 }
 
+// Query returns the underlying query as a regular statement.
+func (b Delete) Query() (string, []interface{}) {
+	ctx := types.NewContext()
+	ctx.Prefix = types.PostgresPrefix
+	b.query.Write(ctx)
+
+	query := ctx.Query()
+	args := ctx.Args()
+
+	return query, args
+}
+
 // Statement returns underlying statement.
 func (b Delete) Statement() stmt.Statement {
 	return b.query

--- a/builder/insert.go
+++ b/builder/insert.go
@@ -149,6 +149,18 @@ func (b Insert) Prepare() (string, map[string]interface{}) {
 	return query, args
 }
 
+// Query returns the underlying query as a regular statement.
+func (b Insert) Query() (string, []interface{}) {
+	ctx := types.NewContext()
+	ctx.Prefix = types.PostgresPrefix
+	b.insert.Write(ctx)
+
+	query := ctx.Query()
+	args := ctx.Args()
+
+	return query, args
+}
+
 // Statement returns underlying statement.
 func (b Insert) Statement() stmt.Statement {
 	return b.insert

--- a/builder/insert.go
+++ b/builder/insert.go
@@ -135,30 +135,23 @@ func (b Insert) Set(args ...interface{}) Insert {
 
 // String returns the underlying query as a raw statement.
 func (b Insert) String() string {
-	return rawify(b.Prepare())
+	var ctx types.RawContext
+	b.insert.Write(&ctx)
+	return ctx.Query()
 }
 
 // Prepare returns the underlying query as a named statement.
 func (b Insert) Prepare() (string, map[string]interface{}) {
-	ctx := types.NewContext()
-	b.insert.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Values()
-
-	return query, args
+	var ctx types.NamedContext
+	b.insert.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Query returns the underlying query as a regular statement.
 func (b Insert) Query() (string, []interface{}) {
-	ctx := types.NewContext()
-	ctx.Prefix = types.PostgresPrefix
-	b.insert.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Args()
-
-	return query, args
+	var ctx types.StdContext
+	b.insert.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Statement returns underlying statement.

--- a/builder/select.go
+++ b/builder/select.go
@@ -226,30 +226,23 @@ func (b Select) Prefix(prefix interface{}) Select {
 
 // String returns the underlying query as a raw statement.
 func (b Select) String() string {
-	return rawify(b.Prepare())
+	var ctx types.RawContext
+	b.query.Write(&ctx)
+	return ctx.Query()
 }
 
 // Prepare returns the underlying query as a named statement.
 func (b Select) Prepare() (string, map[string]interface{}) {
-	ctx := types.NewContext()
-	b.query.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Values()
-
-	return query, args
+	var ctx types.NamedContext
+	b.query.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Query returns the underlying query as a regular statement.
 func (b Select) Query() (string, []interface{}) {
-	ctx := types.NewContext()
-	ctx.Prefix = types.PostgresPrefix
-	b.query.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Args()
-
-	return query, args
+	var ctx types.StdContext
+	b.query.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Statement returns underlying statement.

--- a/builder/select.go
+++ b/builder/select.go
@@ -240,6 +240,18 @@ func (b Select) Prepare() (string, map[string]interface{}) {
 	return query, args
 }
 
+// Query returns the underlying query as a regular statement.
+func (b Select) Query() (string, []interface{}) {
+	ctx := types.NewContext()
+	ctx.Prefix = types.PostgresPrefix
+	b.query.Write(ctx)
+
+	query := ctx.Query()
+	args := ctx.Args()
+
+	return query, args
+}
+
 // Statement returns underlying statement.
 func (b Select) Statement() stmt.Statement {
 	return b.query

--- a/builder/update.go
+++ b/builder/update.go
@@ -97,26 +97,23 @@ func (b Update) Returning(values ...interface{}) Update {
 
 // String returns the underlying query as a raw statement.
 func (b Update) String() string {
-	return rawify(b.Prepare())
+	var ctx types.RawContext
+	b.query.Write(&ctx)
+	return ctx.Query()
 }
 
 // Prepare returns the underlying query as a named statement.
 func (b Update) Prepare() (string, map[string]interface{}) {
-	ctx := types.NewContext()
-	b.query.Write(ctx)
+	var ctx types.NamedContext
+	b.query.Write(&ctx)
 	return ctx.Query(), ctx.Values()
 }
 
 // Query returns the underlying query as a regular statement.
 func (b Update) Query() (string, []interface{}) {
-	ctx := types.NewContext()
-	ctx.Prefix = types.PostgresPrefix
-	b.query.Write(ctx)
-
-	query := ctx.Query()
-	args := ctx.Args()
-
-	return query, args
+	var ctx types.StdContext
+	b.query.Write(&ctx)
+	return ctx.Query(), ctx.Values()
 }
 
 // Statement returns underlying statement.

--- a/builder/update.go
+++ b/builder/update.go
@@ -107,6 +107,18 @@ func (b Update) Prepare() (string, map[string]interface{}) {
 	return ctx.Query(), ctx.Values()
 }
 
+// Query returns the underlying query as a regular statement.
+func (b Update) Query() (string, []interface{}) {
+	ctx := types.NewContext()
+	ctx.Prefix = types.PostgresPrefix
+	b.query.Write(ctx)
+
+	query := ctx.Query()
+	args := ctx.Args()
+
+	return query, args
+}
+
 // Statement returns underlying statement.
 func (b Update) Statement() stmt.Statement {
 	return b.query

--- a/stmt/between.go
+++ b/stmt/between.go
@@ -38,7 +38,7 @@ func NewNotBetween(identifier Identifier, from, to Expression) Between {
 func (Between) expression() {}
 
 // Write exposes statement as a SQL query.
-func (between Between) Write(ctx *types.Context) {
+func (between Between) Write(ctx types.Context) {
 	if between.IsEmpty() {
 		panic("loukoum: expression is undefined")
 	}

--- a/stmt/column.go
+++ b/stmt/column.go
@@ -51,7 +51,7 @@ func (column Column) Desc() Order {
 }
 
 // Write exposes statement as a SQL query.
-func (column Column) Write(ctx *types.Context) {
+func (column Column) Write(ctx types.Context) {
 	ctx.Write(column.Name)
 	if column.Alias != "" {
 		ctx.Write(" ")

--- a/stmt/conflict.go
+++ b/stmt/conflict.go
@@ -20,7 +20,7 @@ func NewOnConflict(target ConflictTarget, action ConflictAction) OnConflict {
 }
 
 // Write exposes statement as a SQL query.
-func (conflict OnConflict) Write(ctx *types.Context) {
+func (conflict OnConflict) Write(ctx types.Context) {
 	if conflict.IsEmpty() {
 		return
 	}
@@ -56,7 +56,7 @@ func NewConflictTarget(columns []Column) ConflictTarget {
 }
 
 // Write exposes statement as a SQL query.
-func (target ConflictTarget) Write(ctx *types.Context) {
+func (target ConflictTarget) Write(ctx types.Context) {
 	if target.IsEmpty() {
 		return
 	}
@@ -96,7 +96,7 @@ func NewConflictUpdateAction(set Set) ConflictUpdateAction {
 }
 
 // Write exposes statement as a SQL query.
-func (action ConflictUpdateAction) Write(ctx *types.Context) {
+func (action ConflictUpdateAction) Write(ctx types.Context) {
 	ctx.Write(token.Do.String())
 	ctx.Write(" ")
 	ctx.Write(token.Update.String())
@@ -120,7 +120,7 @@ func NewConflictNoAction() ConflictNoAction {
 }
 
 // Write exposes statement as a SQL query.
-func (ConflictNoAction) Write(ctx *types.Context) {
+func (ConflictNoAction) Write(ctx types.Context) {
 	ctx.Write(token.Do.String())
 	ctx.Write(" ")
 	ctx.Write(token.Nothing.String())

--- a/stmt/delete.go
+++ b/stmt/delete.go
@@ -19,7 +19,7 @@ func NewDelete() Delete {
 }
 
 // Write exposes statement as a SQL query.
-func (delete Delete) Write(ctx *types.Context) {
+func (delete Delete) Write(ctx types.Context) {
 	if delete.IsEmpty() {
 		panic("loukoum: a delete statement must have a table")
 	}

--- a/stmt/expression.go
+++ b/stmt/expression.go
@@ -185,7 +185,7 @@ func NewIdentifier(identifier string) Identifier {
 func (Identifier) expression() {}
 
 // Write exposes statement as a SQL query.
-func (identifier Identifier) Write(ctx *types.Context) {
+func (identifier Identifier) Write(ctx types.Context) {
 	ctx.Write(identifier.Identifier)
 }
 
@@ -330,7 +330,7 @@ func NewValueFromValuer(valuer driver.Valuer) Value {
 func (Value) expression() {}
 
 // Write exposes statement as a SQL query.
-func (value Value) Write(ctx *types.Context) {
+func (value Value) Write(ctx types.Context) {
 	if value.Value == nil {
 		ctx.Write("NULL")
 	} else {
@@ -489,7 +489,7 @@ func NewArrayFloat64(values []float64) Array {
 func (Array) expression() {}
 
 // Write exposes statement as a SQL query.
-func (array Array) Write(ctx *types.Context) {
+func (array Array) Write(ctx types.Context) {
 	for i := range array.Values {
 		if i != 0 {
 			ctx.Write(", ")
@@ -540,7 +540,7 @@ func NewRaw(value string) Raw {
 func (Raw) expression() {}
 
 // Write exposes statement as a SQL query.
-func (raw Raw) Write(ctx *types.Context) {
+func (raw Raw) Write(ctx types.Context) {
 	ctx.Write(raw.Value)
 }
 

--- a/stmt/expression_test.go
+++ b/stmt/expression_test.go
@@ -17,7 +17,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 	// pq.NullTime
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := pq.NullTime{Valid: true, Time: time.Now()}
 		expression := stmt.NewExpression(source)
@@ -25,7 +25,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 		is.Equal(source.Time, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -33,7 +33,7 @@ func TestExpression_Valuer(t *testing.T) {
 		is.Equal(source.Time, args["arg_1"])
 	}
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := pq.NullTime{}
 		expression := stmt.NewExpression(source)
@@ -41,7 +41,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 		is.Equal(nil, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -51,7 +51,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 	// sql.NullString
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := sql.NullString{Valid: true, String: "ok"}
 		expression := stmt.NewExpression(source)
@@ -59,7 +59,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 		is.Equal(source.String, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -67,7 +67,7 @@ func TestExpression_Valuer(t *testing.T) {
 		is.Equal(source.String, args["arg_1"])
 	}
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := sql.NullString{}
 		expression := stmt.NewExpression(source)
@@ -75,7 +75,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 		is.Equal(nil, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -85,7 +85,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 	// sql.NullInt64
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := sql.NullInt64{Valid: true, Int64: 32}
 		expression := stmt.NewExpression(source)
@@ -93,7 +93,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 		is.Equal(source.Int64, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -101,7 +101,7 @@ func TestExpression_Valuer(t *testing.T) {
 		is.Equal(source.Int64, args["arg_1"])
 	}
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := sql.NullInt64{}
 		expression := stmt.NewExpression(source)
@@ -109,7 +109,7 @@ func TestExpression_Valuer(t *testing.T) {
 
 		is.Equal(nil, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -123,7 +123,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 	// StringEncoder
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := tsencoder{value: "foobar"}
 		expression := stmt.NewExpression(source)
@@ -131,7 +131,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 		is.Equal(source.value, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -141,7 +141,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 	// Int64Encoder
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := tiencoder{value: 32}
 		expression := stmt.NewExpression(source)
@@ -149,7 +149,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 		is.Equal(source.value, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -159,7 +159,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 	// BoolEncoder
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := tbencoder{value: true}
 		expression := stmt.NewExpression(source)
@@ -167,7 +167,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 		is.Equal(source.value, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 
@@ -177,7 +177,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 	// TimeEncoder
 	{
-		ctx := types.NewContext()
+		var ctx types.NamedContext
 
 		source := ttencoder{value: time.Now()}
 		expression := stmt.NewExpression(source)
@@ -185,7 +185,7 @@ func TestExpression_Encoder(t *testing.T) {
 
 		is.Equal(source.value, value.Value)
 
-		value.Write(ctx)
+		value.Write(&ctx)
 		query := ctx.Query()
 		args := ctx.Values()
 

--- a/stmt/from.go
+++ b/stmt/from.go
@@ -20,7 +20,7 @@ func NewFrom(table Table, only bool) From {
 }
 
 // Write exposes statement as a SQL query.
-func (from From) Write(ctx *types.Context) {
+func (from From) Write(ctx types.Context) {
 	ctx.Write(token.From.String())
 	if from.Only {
 		ctx.Write(" ")

--- a/stmt/groupby.go
+++ b/stmt/groupby.go
@@ -18,7 +18,7 @@ func NewGroupBy(columns []Column) GroupBy {
 }
 
 // Write exposes statement as a SQL query.
-func (group GroupBy) Write(ctx *types.Context) {
+func (group GroupBy) Write(ctx types.Context) {
 	ctx.Write(token.Group.String())
 	ctx.Write(" ")
 	ctx.Write(token.By.String())

--- a/stmt/having.go
+++ b/stmt/having.go
@@ -19,7 +19,7 @@ func NewHaving(expression Expression) Having {
 }
 
 // Write exposes statement as a SQL query.
-func (having Having) Write(ctx *types.Context) {
+func (having Having) Write(ctx types.Context) {
 	if having.IsEmpty() {
 		panic("loukoum: a having clause expects at least one condition")
 	}

--- a/stmt/in.go
+++ b/stmt/in.go
@@ -32,7 +32,7 @@ func NewNotIn(identifier Identifier, value Expression) In {
 func (In) expression() {}
 
 // Write exposes statement as a SQL query.
-func (in In) Write(ctx *types.Context) {
+func (in In) Write(ctx types.Context) {
 	if in.IsEmpty() {
 		panic("loukoum: expression is undefined")
 	}

--- a/stmt/infix.go
+++ b/stmt/infix.go
@@ -24,7 +24,7 @@ func NewInfixExpression(left Expression, operator Operator, right Expression) In
 func (InfixExpression) expression() {}
 
 // Write exposes statement as a SQL query.
-func (expression InfixExpression) Write(ctx *types.Context) {
+func (expression InfixExpression) Write(ctx types.Context) {
 	if expression.IsEmpty() {
 		panic("loukoum: expression is undefined")
 	}

--- a/stmt/insert.go
+++ b/stmt/insert.go
@@ -20,7 +20,7 @@ func NewInsert() Insert {
 }
 
 // Write exposes statement as a SQL query.
-func (insert Insert) Write(ctx *types.Context) {
+func (insert Insert) Write(ctx types.Context) {
 	if insert.IsEmpty() {
 		panic("loukoum: an insert statement must have at least one column")
 	}

--- a/stmt/into.go
+++ b/stmt/into.go
@@ -18,7 +18,7 @@ func NewInto(table Table) Into {
 }
 
 // Write exposes statement as a SQL query.
-func (into Into) Write(ctx *types.Context) {
+func (into Into) Write(ctx types.Context) {
 	ctx.Write(token.Into.String())
 	ctx.Write(" ")
 	into.Table.Write(ctx)

--- a/stmt/join.go
+++ b/stmt/join.go
@@ -36,7 +36,7 @@ func NewRightJoin(table Table, condition On) Join {
 }
 
 // Write exposes statement as a SQL query.
-func (join Join) Write(ctx *types.Context) {
+func (join Join) Write(ctx types.Context) {
 	ctx.Write(join.Type.String())
 	ctx.Write(" ")
 	join.Table.Write(ctx)

--- a/stmt/limit.go
+++ b/stmt/limit.go
@@ -20,7 +20,7 @@ func NewLimit(count int64) Limit {
 }
 
 // Write exposes statement as a SQL query.
-func (limit Limit) Write(ctx *types.Context) {
+func (limit Limit) Write(ctx types.Context) {
 	if limit.IsEmpty() {
 		return
 	}

--- a/stmt/offset.go
+++ b/stmt/offset.go
@@ -20,7 +20,7 @@ func NewOffset(start int64) Offset {
 }
 
 // Write exposes statement as a SQL query.
-func (offset Offset) Write(ctx *types.Context) {
+func (offset Offset) Write(ctx types.Context) {
 	if offset.IsEmpty() {
 		return
 	}

--- a/stmt/on.go
+++ b/stmt/on.go
@@ -20,7 +20,7 @@ func NewOn(left, right Column) On {
 }
 
 // Write exposes statement as a SQL query.
-func (on On) Write(ctx *types.Context) {
+func (on On) Write(ctx types.Context) {
 	ctx.Write(token.On.String())
 	ctx.Write(" ")
 	ctx.Write(on.Left.Name)

--- a/stmt/operator.go
+++ b/stmt/operator.go
@@ -35,7 +35,7 @@ func NewLogicalOperator(operator types.LogicalOperator) LogicalOperator {
 func (LogicalOperator) operator() {}
 
 // Write exposes statement as a SQL query.
-func (operator LogicalOperator) Write(ctx *types.Context) {
+func (operator LogicalOperator) Write(ctx types.Context) {
 	ctx.Write(operator.Operator.String())
 }
 
@@ -62,7 +62,7 @@ func NewComparisonOperator(operator types.ComparisonOperator) ComparisonOperator
 func (ComparisonOperator) operator() {}
 
 // Write exposes statement as a SQL query.
-func (operator ComparisonOperator) Write(ctx *types.Context) {
+func (operator ComparisonOperator) Write(ctx types.Context) {
 	ctx.Write(operator.Operator.String())
 }
 

--- a/stmt/order.go
+++ b/stmt/order.go
@@ -19,7 +19,7 @@ func NewOrder(expression string, kind types.OrderType) Order {
 }
 
 // Write exposes statement as a SQL query.
-func (order Order) Write(ctx *types.Context) {
+func (order Order) Write(ctx types.Context) {
 	if order.IsEmpty() {
 		return
 	}

--- a/stmt/orderby.go
+++ b/stmt/orderby.go
@@ -18,7 +18,7 @@ func NewOrderBy(orders []Order) OrderBy {
 }
 
 // Write exposes statement as a SQL query.
-func (order OrderBy) Write(ctx *types.Context) {
+func (order OrderBy) Write(ctx types.Context) {
 	if order.IsEmpty() {
 		return
 	}

--- a/stmt/prefix.go
+++ b/stmt/prefix.go
@@ -17,7 +17,7 @@ func NewPrefix(prefix string) Prefix {
 }
 
 // Write exposes statement as a SQL query.
-func (prefix Prefix) Write(ctx *types.Context) {
+func (prefix Prefix) Write(ctx types.Context) {
 	if prefix.IsEmpty() {
 		return
 	}

--- a/stmt/returning.go
+++ b/stmt/returning.go
@@ -18,7 +18,7 @@ func NewReturning(columns []Column) Returning {
 }
 
 // Write exposes statement as a SQL query.
-func (returning Returning) Write(ctx *types.Context) {
+func (returning Returning) Write(ctx types.Context) {
 	ctx.Write(token.Returning.String())
 	ctx.Write(" ")
 

--- a/stmt/select.go
+++ b/stmt/select.go
@@ -27,7 +27,7 @@ func NewSelect() Select {
 }
 
 // Write exposes statement as a SQL query.
-func (selekt Select) Write(ctx *types.Context) {
+func (selekt Select) Write(ctx types.Context) {
 	if selekt.IsEmpty() {
 		panic("loukoum: select statements must have at least one column")
 	}
@@ -37,7 +37,7 @@ func (selekt Select) Write(ctx *types.Context) {
 	selekt.writeTail(ctx)
 }
 
-func (selekt Select) writeHead(ctx *types.Context) {
+func (selekt Select) writeHead(ctx types.Context) {
 	if !selekt.Prefix.IsEmpty() {
 		selekt.Prefix.Write(ctx)
 		ctx.Write(" ")
@@ -65,7 +65,7 @@ func (selekt Select) writeHead(ctx *types.Context) {
 	}
 }
 
-func (selekt Select) writeMiddle(ctx *types.Context) {
+func (selekt Select) writeMiddle(ctx types.Context) {
 	for i := range selekt.Joins {
 		ctx.Write(" ")
 		selekt.Joins[i].Write(ctx)
@@ -87,7 +87,7 @@ func (selekt Select) writeMiddle(ctx *types.Context) {
 	}
 }
 
-func (selekt Select) writeTail(ctx *types.Context) {
+func (selekt Select) writeTail(ctx types.Context) {
 	if !selekt.OrderBy.IsEmpty() {
 		ctx.Write(" ")
 		selekt.OrderBy.Write(ctx)

--- a/stmt/set.go
+++ b/stmt/set.go
@@ -20,7 +20,7 @@ func NewSet() Set {
 }
 
 // Write exposes statement as a SQL query.
-func (set Set) Write(ctx *types.Context) {
+func (set Set) Write(ctx types.Context) {
 	ctx.Write(token.Set.String())
 	ctx.Write(" ")
 	set.Pairs.Write(ctx)
@@ -150,7 +150,7 @@ func (pairs PairContainer) Values() ([]Column, []Expression) {
 }
 
 // Write exposes statement as a SQL query.
-func (pairs PairContainer) Write(ctx *types.Context) {
+func (pairs PairContainer) Write(ctx types.Context) {
 	if pairs.IsEmpty() {
 		panic("loukoum: values for SET clause are required")
 	}
@@ -163,7 +163,7 @@ func (pairs PairContainer) Write(ctx *types.Context) {
 }
 
 // WriteAssociative exposes statement as a SQL query using a key-value syntax.
-func (pairs PairContainer) WriteAssociative(ctx *types.Context) {
+func (pairs PairContainer) WriteAssociative(ctx types.Context) {
 	columns, expressions := pairs.Values()
 
 	for i := range columns {
@@ -178,7 +178,7 @@ func (pairs PairContainer) WriteAssociative(ctx *types.Context) {
 }
 
 // WriteArray exposes statement as a SQL query using a column-list syntax.
-func (pairs PairContainer) WriteArray(ctx *types.Context) {
+func (pairs PairContainer) WriteArray(ctx types.Context) {
 	ctx.Write("(")
 	for i := range pairs.Columns {
 		if i != 0 {

--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -10,5 +10,5 @@ type Statement interface {
 	// IsEmpty returns true if statement is undefined.
 	IsEmpty() bool
 	// Write exposes statement as a SQL query.
-	Write(ctx *types.Context)
+	Write(ctx types.Context)
 }

--- a/stmt/suffix.go
+++ b/stmt/suffix.go
@@ -17,7 +17,7 @@ func NewSuffix(suffix string) Suffix {
 }
 
 // Write exposes statement as a SQL query.
-func (suffix Suffix) Write(ctx *types.Context) {
+func (suffix Suffix) Write(ctx types.Context) {
 	if suffix.IsEmpty() {
 		return
 	}

--- a/stmt/table.go
+++ b/stmt/table.go
@@ -31,7 +31,7 @@ func (table Table) As(alias string) Table {
 }
 
 // Write exposes statement as a SQL query.
-func (table Table) Write(ctx *types.Context) {
+func (table Table) Write(ctx types.Context) {
 	ctx.Write(table.Name)
 	if table.Alias != "" {
 		ctx.Write(" ")

--- a/stmt/update.go
+++ b/stmt/update.go
@@ -24,7 +24,7 @@ func NewUpdate(table Table) Update {
 }
 
 // Write exposes statement as a SQL query.
-func (update Update) Write(ctx *types.Context) {
+func (update Update) Write(ctx types.Context) {
 	if update.IsEmpty() {
 		panic("loukoum: an update statement must have a table and/or values")
 	}

--- a/stmt/using.go
+++ b/stmt/using.go
@@ -18,7 +18,7 @@ func NewUsing(tables []Table) Using {
 }
 
 // Write exposes statement as a SQL query.
-func (using Using) Write(ctx *types.Context) {
+func (using Using) Write(ctx types.Context) {
 	if using.IsEmpty() {
 		return
 	}

--- a/stmt/values.go
+++ b/stmt/values.go
@@ -18,7 +18,7 @@ func NewValues(values Expression) Values {
 }
 
 // Write exposes statement as a SQL query.
-func (values Values) Write(ctx *types.Context) {
+func (values Values) Write(ctx types.Context) {
 	if values.IsEmpty() {
 		return
 	}

--- a/stmt/where.go
+++ b/stmt/where.go
@@ -18,7 +18,7 @@ func NewWhere(expression Expression) Where {
 }
 
 // Write exposes statement as a SQL query.
-func (where Where) Write(ctx *types.Context) {
+func (where Where) Write(ctx types.Context) {
 	if where.IsEmpty() {
 		panic("loukoum: a where clause expects at least one condition")
 	}

--- a/types/context.go
+++ b/types/context.go
@@ -7,8 +7,13 @@ import (
 
 // A Context is passed to a root stmt.Statement to generate a query.
 type Context struct {
+
+	// Prefix added to query placeholders
+	Prefix string
+
 	buffer bytes.Buffer
 	values map[string]interface{}
+	args   []interface{}
 }
 
 // Write appends given subquery in context's buffer.
@@ -21,11 +26,11 @@ func (ctx *Context) Write(query string) {
 
 // Bind adds given value in context's values.
 func (ctx *Context) Bind(value interface{}) {
-	idx := len(ctx.values) + 1
-	key := fmt.Sprintf("arg_%d", idx)
-	ctx.values[key] = value
-	ctx.Write(":")
-	ctx.Write(key)
+	idx := len(ctx.args) + 1
+	name := fmt.Sprintf("arg_%d", idx)
+	ctx.values[name] = value
+	ctx.args = append(ctx.args, value)
+	ctx.Write(fmt.Sprintf("%s%d", ctx.Prefix, idx))
 }
 
 // Query returns the underlaying query.
@@ -38,9 +43,21 @@ func (ctx *Context) Values() map[string]interface{} {
 	return ctx.values
 }
 
+// Args return the underlying values of the query as a slice.
+func (ctx *Context) Args() []interface{} {
+	return ctx.args
+}
+
+// Placeholder prefixes
+const (
+	NamedPrefix    = ":arg_"
+	PostgresPrefix = "$"
+)
+
 // NewContext creates a new Context instance.
 func NewContext() *Context {
 	return &Context{
+		Prefix: NamedPrefix,
 		values: make(map[string]interface{}),
 	}
 }

--- a/types/context.go
+++ b/types/context.go
@@ -11,7 +11,6 @@ import (
 type Context interface {
 	Write(query string)
 	Bind(value interface{})
-	Query() string
 }
 
 // RawContext embeds values directly in the query.

--- a/types/context.go
+++ b/types/context.go
@@ -16,7 +16,6 @@ type Context interface {
 // RawContext embeds values directly in the query.
 type RawContext struct {
 	buffer bytes.Buffer
-	values map[string]interface{}
 }
 
 // Write appends given subquery in context's buffer.

--- a/types/context.go
+++ b/types/context.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/ulule/loukoum/format"
 )
 


### PR DESCRIPTION
The query methods generate a query & args that can be used by the `database/sql` package.

``` go
query, args := lk.Select("*").From("foo").Query()
rows, err := db.Query(query, args...)
```

This addresses #26 but it's also useful with sqlx (which I'm using). It lets you use the `sqlx.DB.Select` and `sqlx.DB.Get` methods without creating a statement (which is clunky).