### PR TITLE
Close statements in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ func CreateComment(db *sqlx.DB, comment Comment) (Comment, error) {
 	if err != nil {
 		return comment, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Get(&comment, args)
 	if err != nil {
@@ -134,6 +135,7 @@ func UpsertComment(db *sqlx.DB, comment Comment) (Comment, error) {
 	if err != nil {
 		return comment, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Get(&comment, args)
 	if err != nil {
@@ -179,6 +181,7 @@ func PublishNews(db *sqlx.DB, news News) (News, error) {
 	if err != nil {
 		return news, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Get(&news, args)
 	if err != nil {
@@ -225,6 +228,7 @@ func FindUsers(db *sqlx.DB) ([]User, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Select(&users, args)
 	if err != nil {
@@ -258,6 +262,7 @@ func FindStaffComments(db *sqlx.DB, comment Comment) ([]Comment, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
 
 	comments := []Comment{}
 
@@ -311,6 +316,7 @@ func FindComments(db *sqlx.DB, comment Comment) ([]Comment, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
 
 	comments := []Comment{}
 
@@ -343,6 +349,7 @@ func DeleteUser(db *sqlx.DB, user User) error {
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 
 	_, err = stmt.Exec(args)
 

--- a/examples/comment.go
+++ b/examples/comment.go
@@ -35,6 +35,7 @@ func FindComments(db *sqlx.DB, comment Comment) ([]Comment, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
 
 	comments := []Comment{}
 
@@ -67,6 +68,7 @@ func FindStaffComments(db *sqlx.DB, comment Comment) ([]Comment, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
 
 	comments := []Comment{}
 
@@ -101,6 +103,7 @@ func CreateComment(db *sqlx.DB, comment Comment) (Comment, error) {
 	if err != nil {
 		return comment, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Get(&comment, args)
 	if err != nil {
@@ -143,6 +146,7 @@ func UpsertComment(db *sqlx.DB, comment Comment) (Comment, error) {
 	if err != nil {
 		return comment, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Get(&comment, args)
 	if err != nil {

--- a/examples/news.go
+++ b/examples/news.go
@@ -36,6 +36,7 @@ func PublishNews(db *sqlx.DB, news News) (News, error) {
 	if err != nil {
 		return news, err
 	}
+	defer stmt.Close()
 
 	err = stmt.Get(&news, args)
 	if err != nil {

--- a/examples/user.go
+++ b/examples/user.go
@@ -31,6 +31,7 @@ func FindUsers(db *sqlx.DB) ([]User, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
 
 	users := []User{}
 
@@ -57,6 +58,7 @@ func DeleteUser(db *sqlx.DB, user User) error {
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 
 	_, err = stmt.Exec(args)
 


### PR DESCRIPTION
Adding the missing Close() calls on the statements in your examples.