### PR TITLE
Change offset minimum value to 0

### DIFF
--- a/builder/select.go
+++ b/builder/select.go
@@ -193,8 +193,8 @@ func (b Select) Offset(value interface{}) Select {
 	}
 
 	offset, ok := ToInt64(value)
-	if !ok || offset <= 0 {
-		panic("loukoum: offset must be a positive integer")
+	if !ok || offset < 0 {
+		panic("loukoum: offset must be a non-negative integer")
 	}
 
 	b.query.Offset = stmt.NewOffset(offset)


### PR DESCRIPTION
Is it really necessary for offset to be greater than 0?

My default values are 0, so I need to check every time whether offset is greater than 0.

I suppose it should return first page if offset is 0?