### PR TITLE
Add stmt.Raw to stmt.NewArrayExpression

### DIFF
--- a/stmt/expression.go
+++ b/stmt/expression.go
@@ -99,6 +99,9 @@ func NewArrayExpression(values ...interface{}) Expression { // nolint: gocyclo
 		case driver.Valuer:
 			return NewExpression(value)
 
+		case Raw:
+			return NewExpression(value)
+
 		case Select:
 			return NewExpression(value)
 


### PR DESCRIPTION
stmt.NewArrayExpression return an error
if value has a stmt.Raw type.

The following use case is not possible:
```
b := lk.Select("name").From("users").
    Where(lk.Condition("id").In(lk.Raw("?")))
```