### PR TITLE
Emit IN when the value is empty.

### DIFF
--- a/builder/select_test.go
+++ b/builder/select_test.go
@@ -774,6 +774,14 @@ func TestSelect_WhereIn(t *testing.T) {
 			NamedQuery: "SELECT id FROM table WHERE (id NOT IN (SELECT id FROM table WHERE (id = :arg_1)))",
 			Args:       []interface{}{1},
 		},
+		{
+			Name: "In empty slice",
+			Builder: loukoum.
+				Select("id").From("table").Where(
+				loukoum.Condition("id").In([]int{}),
+			),
+			SameQuery: "SELECT id FROM table WHERE (id IN ())",
+		},
 	})
 }
 

--- a/stmt/in.go
+++ b/stmt/in.go
@@ -42,13 +42,15 @@ func (in In) Write(ctx types.Context) {
 	ctx.Write(" ")
 	in.Operator.Write(ctx)
 	ctx.Write(" (")
-	in.Value.Write(ctx)
+	if !in.Value.IsEmpty() {
+		in.Value.Write(ctx)
+	}
 	ctx.Write("))")
 }
 
 // IsEmpty returns true if statement is undefined.
 func (in In) IsEmpty() bool {
-	return in.Identifier.IsEmpty() || in.Operator.IsEmpty() || in.Value == nil || in.Value.IsEmpty()
+	return in.Identifier.IsEmpty() || in.Operator.IsEmpty() || in.Value == nil
 }
 
 // And creates a new InfixExpression using given Expression.


### PR DESCRIPTION
Fixes #49 this solution let's us keep `Array.IsEmpty` the way it is.