### PR TITLE
Use stmt.Limit and stmt.Order in Select builder

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -347,3 +347,37 @@ func ToSet(args []interface{}) stmt.Set {
 	set = MergeSet(set, args)
 	return set
 }
+
+// ToLimit takes an empty interfaces and returns a Limit instance.
+func ToLimit(arg interface{}) stmt.Limit {
+	switch value := arg.(type) {
+	case stmt.Limit:
+		return value
+	default:
+		limit, ok := ToInt64(value)
+		if !ok {
+			panic(fmt.Sprintf("loukoum: cannot use %T as limit", value))
+		}
+		if limit <= 0 {
+			panic("loukoum: limit must be a positive integer")
+		}
+		return stmt.NewLimit(limit)
+	}
+}
+
+// ToOffset takes an empty interfaces and returns a Offset instance.
+func ToOffset(arg interface{}) stmt.Offset {
+	switch value := arg.(type) {
+	case stmt.Offset:
+		return value
+	default:
+		offset, ok := ToInt64(value)
+		if !ok {
+			panic(fmt.Sprintf("loukoum: cannot use %T as offset", value))
+		}
+		if offset < 0 {
+			panic("loukoum: offset must be a non-negative integer")
+		}
+		return stmt.NewOffset(offset)
+	}
+}

--- a/builder/select.go
+++ b/builder/select.go
@@ -187,13 +187,7 @@ func (b Select) Limit(value interface{}) Select {
 		panic("loukoum: select builder has limit clause already defined")
 	}
 
-	limit, ok := ToInt64(value)
-	if !ok || limit <= 0 {
-		panic("loukoum: limit must be a positive integer")
-	}
-
-	b.query.Limit = stmt.NewLimit(limit)
-
+	b.query.Limit = ToLimit(value)
 	return b
 }
 
@@ -203,13 +197,7 @@ func (b Select) Offset(value interface{}) Select {
 		panic("loukoum: select builder has offset clause already defined")
 	}
 
-	offset, ok := ToInt64(value)
-	if !ok || offset < 0 {
-		panic("loukoum: offset must be a non-negative integer")
-	}
-
-	b.query.Offset = stmt.NewOffset(offset)
-
+	b.query.Offset = ToOffset(value)
 	return b
 }
 


### PR DESCRIPTION
This pull request add the support of `stmt.Limit` and `stmt.Order` in the Select builder.