### PR TITLE
fix: allow raw condition to avoid quoting

### DIFF
--- a/builder/select_test.go
+++ b/builder/select_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lib/pq"
 	loukoum "github.com/ulule/loukoum/v3"
 	"github.com/ulule/loukoum/v3/builder"
 	"github.com/ulule/loukoum/v3/stmt"
@@ -695,6 +696,17 @@ func TestSelect_WhereEqual(t *testing.T) {
 			Query:      "SELECT \"id\" FROM \"table\" WHERE (upper(\"email\") = $1)",
 			NamedQuery: "SELECT \"id\" FROM \"table\" WHERE (upper(\"email\") = :arg_1)",
 			Args:       []interface{}{"FOO@EXAMPLE.ORG"},
+		},
+		{
+			Name: "Raw Equal",
+			Builder: loukoum.
+				Select("id").
+				From("table").
+				Where(loukoum.Condition(loukoum.Raw("string_to_array(languages, ',')")).Overlap(pq.StringArray{"fr"})),
+			String:     "SELECT \"id\" FROM \"table\" WHERE (string_to_array(languages, ',') && '{\"fr\"}')",
+			Query:      "SELECT \"id\" FROM \"table\" WHERE (string_to_array(languages, ',') && $1)",
+			NamedQuery: "SELECT \"id\" FROM \"table\" WHERE (string_to_array(languages, ',') && :arg_1)",
+			Args:       []interface{}{pq.StringArray{"fr"}},
 		},
 	})
 }

--- a/loukoum.go
+++ b/loukoum.go
@@ -67,7 +67,7 @@ func OrOn(left stmt.OnExpression, right stmt.OnExpression) stmt.OnExpression {
 }
 
 // Condition is a wrapper to create a new Identifier statement.
-func Condition(column string) stmt.Identifier {
+func Condition(column interface{}) stmt.Identifier {
 	return stmt.NewIdentifier(column)
 }
 

--- a/stmt/expression.go
+++ b/stmt/expression.go
@@ -57,11 +57,11 @@ func NewExpression(arg interface{}) Expression { // nolint: gocyclo
 
 // Identifier is an identifier.
 type Identifier struct {
-	Identifier string
+	Identifier interface{}
 }
 
 // NewIdentifier returns a new Identifier.
-func NewIdentifier(identifier string) Identifier {
+func NewIdentifier(identifier interface{}) Identifier {
 	return Identifier{
 		Identifier: identifier,
 	}
@@ -71,7 +71,12 @@ func (Identifier) expression() {}
 
 // Write exposes statement as a SQL query.
 func (identifier Identifier) Write(ctx types.Context) {
-	ctx.Write(quote(identifier.Identifier))
+	switch v := identifier.Identifier.(type) {
+	case Expression:
+		v.Write(ctx)
+	case string:
+		ctx.Write(quote(v))
+	}
 }
 
 // IsEmpty returns true if statement is undefined.


### PR DESCRIPTION
Fix [crash](https://sentry.io/organizations/ulule/issues/2372129582/?project=79212&query=is%3Aunresolved) when a column name is an expression.