### PR TITLE
fix: panic if condition is nil on WHERE / AND clauses

### DIFF
--- a/builder/select.go
+++ b/builder/select.go
@@ -144,6 +144,9 @@ func (b Select) With(args ...stmt.WithQuery) Select {
 
 // Where adds WHERE clauses.
 func (b Select) Where(condition stmt.Expression) Select {
+	if condition == nil {
+		panic("loukoum: condition must be not nil")
+	}
 	if b.query.Where.IsEmpty() {
 		b.query.Where = stmt.NewWhere(condition)
 		return b
@@ -154,6 +157,9 @@ func (b Select) Where(condition stmt.Expression) Select {
 
 // And adds AND WHERE conditions.
 func (b Select) And(condition stmt.Expression) Select {
+	if condition == nil {
+		panic("loukoum: condition must be not nil")
+	}
 	b.query.Where = b.query.Where.And(condition)
 	return b
 }

--- a/builder/select_test.go
+++ b/builder/select_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	loukoum "github.com/ulule/loukoum/v3"
 	"github.com/ulule/loukoum/v3/builder"
 	"github.com/ulule/loukoum/v3/stmt"
@@ -1553,5 +1554,23 @@ func TestSelect_Extra(t *testing.T) {
 				Suffix("FOR UPDATE"),
 			SameQuery: "SELECT name FROM user FOR UPDATE",
 		},
+	})
+}
+
+func TestSelect_NilCondition(t *testing.T) {
+	is := require.New(t)
+	is.Panics(func() {
+		var nilcond stmt.Expression
+		loukoum.Select("col").
+			From("table").
+			Where(loukoum.Condition("col").Equal("value")).
+			And(nilcond)
+	})
+
+	is.Panics(func() {
+		var nilcond stmt.Expression
+		loukoum.Select("col").
+			From("table").
+			Where(nilcond)
 	})
 }


### PR DESCRIPTION
There is a bug when you write a WHERE and or AND clause with the condition nil.
The WHERE clause is not written.

```go
package main

import (
	"fmt"

	"github.com/ulule/loukoum/v3"
	"github.com/ulule/loukoum/v3/stmt"
)

func main() {
	var cursorcond stmt.Expression
	q, args :=
		loukoum.Select("col").
			From("table").
			Where(loukoum.Condition("col").Equal("value")).
			And(cursorcond).
			OrderBy(loukoum.Order("col")).
			Limit(1).
			Query()
	fmt.Println(q, args)
}
```
`SELECT "col" FROM "table" ORDER BY col ASC LIMIT 1 []`
